### PR TITLE
Compute python version string by its major/minor parts

### DIFF
--- a/recorder/prefix.py
+++ b/recorder/prefix.py
@@ -46,7 +46,7 @@ def prefix(join=None):
         # to match: /usr/lib/python2.5/site-packages/project/prefix.py
         # or: /usr/local/lib/python2.6/dist-packages/project/prefix.py
         lambda x: x == 'lib',
-        lambda x: x == ('python%s' % sys.version[:3]),
+        lambda x: x == f"python{sys.version_info.major}.{sys.version_info.minor}",
         lambda x: x in ['site-packages', 'dist-packages'],
         lambda x: x == name,    # 'project'
         lambda x: x == this,    # 'prefix.py'


### PR DESCRIPTION
Previous code extracted major/minor versions from the `sys.version` and
just worked for single-digit minor versions (i.e., before 3.10).
This commit uses `sys.version_info` so it does not need to extract
version information manually.